### PR TITLE
chore: added coverage run open

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,2 @@
 npm run test --coverage --ui
+npm run coverage:open


### PR DESCRIPTION

<!-- Do not delete this PR template. Just edit it to include the required information -->

# Description

**Closes #22**

This pull request updates the Husky `pre-push` hook to automatically open the coverage report UI after running tests. This makes it easier for contributors to instantly visualize test coverage and identify untested parts of the codebase before pushing.

# Changes proposed

## What were you told to do?

Improve the development workflow by ensuring contributors get quick access to test coverage results.

## What did you do?

* Updated the `.husky/pre-push` file
* Added a second command: `npm run coverage:open`, right after the test with coverage command
* This opens the test coverage report in the browser automatically after tests run

# Check List (Check all the applicable boxes)

* [x] My code follows the code style of this project.
* [x] This PR does not contain plagiarized content.
* [x] The title and description of the PR is clear and explains the approach.
* [x] I am making a pull request against the **dev branch** (left side).
* [x] My commit messages styles matches our requested structure.
* [x] My code additions will fail neither code linting checks nor unit test.
* [x] I am only making changes to files I was requested to.

# Screenshots/Videos

*Not applicable — this is a workflow/tooling update and does not involve UI or API changes.*

---

Let me know if you need a PR title or if the project requires labels like `chore`, `dev-tooling`, etc. I can suggest those too.
