### PR TITLE
Feat/authentication schema

### DIFF
--- a/src/schemas/auth.ts
+++ b/src/schemas/auth.ts
@@ -29,3 +29,7 @@ export const ResetPassword = z
     message: "passwords do not match",
     path: ["confirmPassword"],
   });
+
+export const forgotPassowrdSchema = z.object({
+  email: z.string().email({ message: "password is required" }),
+});

--- a/src/schemas/auth.ts
+++ b/src/schemas/auth.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+export const registerSchema = z.object({
+  email: z
+    .string()
+    .min(1, { message: "Email is required" })
+    .email({ message: "invalid email" }),
+  password: z.string().min(8, { message: "password is required" }),
+  username: z
+    .string()
+    .min(1, { message: "username is required" })
+    .min(3, { message: "username should be at least 3 characters" }),
+});
+
+export const LoginSchema = z.object({
+  email: z.string().email({ message: "invalid email" }),
+  password: z.string().min(8, { message: "password is required" }),
+  rememberMe: z.boolean().default(false).optional(),
+});
+
+export const ResetPassword = z
+  .object({
+    password: z.string().min(8, { message: "password is required" }),
+    confirmPassword: z
+      .string()
+      .min(8, { message: "confirm password is required" }),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "passwords do not match",
+    path: ["confirmPassword"],
+  });


### PR DESCRIPTION
<!-- Do not delete this PR template. Just edit it to include the required information -->

# Description

**Closes #23**

# Changes proposed

**Create and export validation schemas for all authentication-related actions using Zod.  
This includes register, login, forgot password, and reset password schemas, following the structure and rules defined in the Linear ticket.
**

## What were you told to do?

Create and define authentication-related schemas for validation using Zod in the backend.

## What did you do?

- Created a new file named `auth.ts` in the `schema` folder.
- Added the following Zod validation schemas:
  - `registerSchema` for validating user registration data.
  - `LoginSchema` for login input validation, including optional `rememberMe` flag.
  - `ResetPassword` schema with password confirmation logic.
  - `forgotPassowrdSchema` for validating forgot-password email input.

# Check List (Check all the applicable boxes)

- [X] My code follows the code style of this project.
- [X] This PR does not contain plagiarized content.
- [X] The title and description of the PR is clear and explains the approach.
- [X] I am making a pull request against the **dev branch** (left side).
- [X] My commit messages styles matches our requested structure.
- [X] My code additions will fail neither code linting checks nor unit test.
- [X] I am only making changes to files I was requested to.

# Screenshots/Videos

_N/A — this PR involves schema definitions only._
